### PR TITLE
Remove Travis build status from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Apache Fineract CN Provisioner [![Build Status](https://api.travis-ci.com/apache/fineract-cn-provisioner.svg?branch=develop)](https://travis-ci.com/apache/fineract-cn-provisioner) [![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/apache/fineract-cn-provisioner)](https://hub.docker.com/r/apache/fineract-cn-provisioner/builds)
+# Apache Fineract CN Provisioner [![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/apache/fineract-cn-provisioner)](https://hub.docker.com/r/apache/fineract-cn-provisioner/builds)
 
 
 This service provisions services for tenants of an Apache Fineract CN installation.


### PR DESCRIPTION
Due to the removal of the Travis build scripts from the project. The build status in the README.md is now misleading and needs to be removed.